### PR TITLE
Fix: Push Docker image only on non-PR events

### DIFF
--- a/.github/workflows/build_server.yml
+++ b/.github/workflows/build_server.yml
@@ -111,6 +111,6 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ${{secrets.DOCKERHUB_USERNAME}}/query-pdb-server:latest

--- a/.github/workflows/build_server.yml
+++ b/.github/workflows/build_server.yml
@@ -98,6 +98,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Login to Docker Hub
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@v2
         with:
           username: ${{secrets.DOCKERHUB_USERNAME}}

--- a/.github/workflows/build_server.yml
+++ b/.github/workflows/build_server.yml
@@ -114,4 +114,4 @@ jobs:
           file: Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
-            ${{secrets.DOCKERHUB_USERNAME}}/query-pdb-server:latest
+            zouxianyu/query-pdb-server:latest


### PR DESCRIPTION
Update the build_server workflow to push the Docker image only if the event is not a pull request. This prevents images from being pushed during pull request builds.